### PR TITLE
Version 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "3loc",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A simple-yet-customizable integration test tool",
   "bin": {
     "run": "src/cli.js"
   },
   "scripts": {
-    "test": "gulp test"
+    "test": "gulp test",
+    "dev": "gulp"
   },
   "repository": {
     "type": "git",

--- a/readme.md
+++ b/readme.md
@@ -477,6 +477,14 @@ then(expectToMatchXsd(load('schema.xsd')))
 
 Logger name: `expect:xsd`
 
+
+# Changelog
+
+## 0.5.0
+- add test coverage for Nunjuck unquote helper
+- fix timeout that applies to all suite and provide dedicated input field
+- configure all loggers at once with `all`
+
 [node]: https://nodejs.org/en/download/
 [act]: #available-actions
 [expect]: #expectations

--- a/readme.md
+++ b/readme.md
@@ -161,6 +161,9 @@ level=error
 level=debug
 ```
 
+You can provide a category named `all` in order to customize all loggers level at once.
+This `all` general configuration will always be overriden by logger-specific configuration.
+
 The conf is regularly watched so you can change you file while 3loc is running.
 
 By convention, each actions/expectation uses its own logger, so you can have a fine-grained tunning.

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ If received results are not the one expected, it will complain.
 
 It's focused on Http services, SOAP and REST.
 
-Test scenarii are basically JavaScript files, containing a serie of *[actions][act]* and *[expectations][expect]*.
+Test scenarii are basically JavaScript files, containing a series of *[actions][act]* and *[expectations][expect]*.
 You will surely need to run the same scenario multiple times, with slight changes in the test data: body sent to the tested WebService, or expected status code.
 
 We called them *[fixtures][fixt]*, and you can externalize them in a dedicated file (multiple format are supported).
@@ -61,7 +61,7 @@ return () =>
 It makes an Http call to the [Wolfram API][wolfram], get and parse the XML content,
 checks the received status code and check the result with an XPath expression.
 
-See thoses `<$ $>` placeholders (`input`, `sum`...) ? they are replaced with the provided test data.
+See those `<$ $>` placeholders (`input`, `sum`...) ? they are replaced with the provided test data.
 
 
 ## With YAML
@@ -73,6 +73,7 @@ scenario: ./path_to/my-scenario.scn
 appId: HLJL66-4W3HPXYYP8
 tests:
   - name: nominal case
+    timeout: 3000
     input: 3%2B4
     sum: 7
     status: 200
@@ -96,6 +97,9 @@ The content will be used inside the scenario file:
 If you specify a `name` at test level, it will be used in final report.
 Otherwise, a name with test number will be generated.
 
+You can also provide a test-specific timeout (in millisecond, default to 2000).
+
+
 You can't use different scenarii for each test. If you whish, write different fixtures files.
 
 Last but not least, a YAML file can include other YAML files, using the following *macro*:
@@ -103,14 +107,8 @@ Last but not least, a YAML file can include other YAML files, using the followin
 config: !!inc/file configuration.yaml
 ```
 
-
 The `!!inc/file` performs a *synchronous* read of the given path (relative to the including file) and is replaced by its content.
 
-In this `config` array, you can set a `timeout` to modify the duration of the test suite created for your scenarii
-```yaml
-config: 
-  timeout: 5000
-```
 
 ## With CSV
 
@@ -132,6 +130,8 @@ and the data is an `host` object containing an `url` property.
 
 If you specify a `name` column, it will be used in final report.
 Otherwise, a name with test number will be generated.
+
+You can also set a `timeout` column to customize tests timeout (in millisecond, default to 2000).
 
 You can't share data among different tests. For that, please use a YAML fixture file.
 

--- a/src/engine/test.js
+++ b/src/engine/test.js
@@ -24,11 +24,13 @@ module.exports = class Test {
    * @param {String} name - test's name
    * @param {String} file - scenario file path or directly scenario content
    * @param {Object} fixtures - test data fixtures
+   * @param {Integer} timeout = 2000 - test specific timeout
    * @param {String} workdir = '.' - path used as execution working folder
    */
-  constructor(name, file, fixtures, workdir) {
+  constructor(name, file, fixtures, timeout, workdir) {
     this.name = name;
     this.file = file;
+    this.timeout = timeout || 2000;
     this.workdir = workdir || `.`;
     if (!fixtures) {
       throw new Error(`can't create ${this.constructor.name} scenario without fixtures`);

--- a/src/parser/csv.js
+++ b/src/parser/csv.js
@@ -62,15 +62,17 @@ const parseFile = content =>
       const tests = [];
       let i = 1;
       for (let fixture of fixtures) {
-        let name = fixture.name || `test ${i++}`;
-        let scenario = fixture.scenario;
+        const name = fixture.name || `test ${i++}`;
+        const scenario = fixture.scenario;
+        const timeout = fixture.timeout;
         if (!scenario) {
           reject(new Error(`Missing scenario for test ${name}`));
           break;
         }
         delete fixture.name;
         delete fixture.scenario;
-        tests.push(new Test(name, scenario, unflatten(fixture)));
+        delete fixture.timeout;
+        tests.push(new Test(name, scenario, unflatten(fixture), timeout));
       }
       resolve(tests);
     })

--- a/src/parser/yaml.js
+++ b/src/parser/yaml.js
@@ -75,9 +75,9 @@ const parseFile = (fullpath, content) =>
 
         if (Array.isArray(spec.tests)) {
           result = spec.tests.map((fixture, i) => {
-            let name = fixture.name || `test ${i + 1}`;
+            const name = fixture.name || `test ${i + 1}`;
             // creates scenario with common values, but possibility to be specific overloaded
-            return new Test(name, scenario, _.merge({}, common, _.omit(fixture, `name`)), workdir);
+            return new Test(name, scenario, _.merge({}, common, _.omit(fixture, `name`, `timeout`)), fixture.timeout, workdir);
           });
         }
         resolve(result);

--- a/src/runner/mocha.js
+++ b/src/runner/mocha.js
@@ -18,12 +18,12 @@ const toMocha = (tests, suiteName) => {
   // declares a single describe for all tests.
   const suite = new Suite(suiteName);
   // and declares all specified tests
-  for (let test of tests) {
-    if (test.fixtures.config && test.fixtures.config.timeout) {
-      let timeout = test.fixtures.config.timeout;
-      suite.timeout(timeout > 0 ? timeout : 2000);
-    }
-    suite.addTest(new Test(test.name, () => test.run()));
+  for (let spec of tests) {
+    let test = new Test(spec.name, () => spec.run());
+    suite.addTest(test);
+    // test timeout should be set after affectation to a suite,
+    // suite propagate its own timeout first
+    test.timeout(spec.timeout);
   }
   return suite;
 };

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -78,6 +78,11 @@ const reloadConf = (confPath, sync) =>
   then(conf => {
     // tries to update existing loggers
     for (let name in loggers) {
+      // update first with general level
+      if (conf.all && conf.all.level) {
+        loggers[name].level = conf.all.level;
+      }
+      // optionnally overrides with specific logger's level
       if (conf[name] && conf[name].level) {
         loggers[name].level = conf[name].level;
       }

--- a/test/actions/render.js
+++ b/test/actions/render.js
@@ -44,6 +44,14 @@ describe(`Nunjucks rendering action`, () => {
       });
   });
 
+  it(`should not quote strings data when using 'unquote' helper`, () => {
+    const data = {name: `Damien`, polite: false};
+    return run(render(`Hello <$ name | unquote $><% if polite %>, nice to meet you<% endif %>.`, data)).
+      then(result => {
+        expect(result).to.have.property(`content`).that.equals(`Hello Damien.`);
+      });
+  });
+
   it(`should render template without data`, () => {
     return run(render(`Hello !`)).
       then(result => {

--- a/test/engine/test.js
+++ b/test/engine/test.js
@@ -18,8 +18,13 @@ describe(`Test class`, () => {
     )).to.throw(/without fixtures/);
   });
 
+  it(`should allow to customize timeout value`, () => {
+    expect(new Test(`test 1`, `return () => {}`, {})).to.have.property(`timeout`).that.equals(2000);
+    expect(new Test(`test 2`, `return () => {}`, {}, 500)).to.have.property(`timeout`).that.equals(500);
+  });
+
   it(`should use specified current directory`, () => {
-    return new Test(`test 1`, `return () => process.cwd();`, {}, __dirname).
+    return new Test(`test 1`, `return () => process.cwd();`, {}, null, __dirname).
       run().
       then(result => expect(result).to.equals(__dirname));
   });

--- a/test/fixtures/csv/simple.csv
+++ b/test/fixtures/csv/simple.csv
@@ -1,2 +1,2 @@
-scenario;name;id;vehicle;insurer;scoring;acceleration;coasting;constant;trackOn;trackOff;score
-./fixtures/scn/noop.scn;mon test 1;123456;123456;IN1;C1;50;20;30;;;53
+scenario;name;timeout;id;vehicle;insurer;scoring;acceleration;coasting;constant;trackOn;trackOff;score
+./fixtures/scn/noop.scn;mon test 1;500;123456;123456;IN1;C1;50;20;30;;;53

--- a/test/fixtures/csv/timeout.csv
+++ b/test/fixtures/csv/timeout.csv
@@ -1,0 +1,3 @@
+scenario;name;timeout;id;vehicle;insurer;scoring;acceleration;coasting;constant;trackOn;trackOff;score
+./fixtures/scn/noop.scn;mon test 1;3000;123456;123456;IN1;C1;50;20;30;;;53
+./fixtures/scn/noop.scn;mon test 2;;123457;123457;IN2;C2;50;20;30;;;60

--- a/test/fixtures/yaml/simple.yaml
+++ b/test/fixtures/yaml/simple.yaml
@@ -1,6 +1,7 @@
 scenario: ./fixtures/scn/noop.scn
 tests:
   - name: first test
+    timeout: 500
     id: 123456
     vehicle: 123456
     insurer: IN1

--- a/test/fixtures/yaml/timeout.yaml
+++ b/test/fixtures/yaml/timeout.yaml
@@ -1,0 +1,5 @@
+scenario: ./fixtures/scn/noop.scn
+tests:
+  - name: test 1
+    timeout: 3000
+  - name: test 2

--- a/test/helpers/helpers.js
+++ b/test/helpers/helpers.js
@@ -5,6 +5,16 @@ const helpers = require(`../../src/helpers`);
 
 describe(`Nunjucks helpers`, () => {
 
+  describe(`unquote`, () => {
+
+    it(`should unquote only strings`, () => {
+      const unquoted = helpers.unquote(`something`);
+      expect(unquoted).to.be.an.instanceof(String);
+      expect(unquoted.toString()).to.equals(`something`);
+      expect(unquoted).to.have.property(`unquote`).that.is.true;
+    });
+  });
+
   describe(`stringify`, () => {
 
     it(`should stringify plain variables`, () => {

--- a/test/parser/csv.js
+++ b/test/parser/csv.js
@@ -73,14 +73,28 @@ describe(`CSV parser`, () => {
     });
   });
 
+  it(`should extract test timeout`, () => {
+    return parse(join(fixtures, `timeout.csv`)).then(scenarii => {
+      expect(scenarii).to.have.lengthOf(2);
+      expect(scenarii[0]).to.be.an.instanceOf(Test);
+      expect(scenarii[0]).to.have.property(`timeout`).that.equals(3000);
+      expect(scenarii[1]).to.be.an.instanceOf(Test);
+      expect(scenarii[1]).to.have.property(`timeout`).that.equals(2000);
+    });
+  });
+
   it(`should extract Spec instances`, () => {
     return parse(join(fixtures, `simple.csv`)).then(scenarii => {
       expect(scenarii).to.have.lengthOf(1);
       expect(scenarii[0]).to.be.an.instanceOf(Test);
       expect(scenarii[0]).to.have.property(`name`).that.equals(`mon test 1`);
+      expect(scenarii[0]).to.have.property(`timeout`).that.equals(500);
       expect(scenarii[0].fixtures).to.have.property(`id`).that.equals(123456);
       expect(scenarii[0].fixtures).to.have.property(`insurer`).that.equals(`IN1`);
       expect(scenarii[0].fixtures).to.have.property(`scoring`).that.equals(`C1`);
+      expect(scenarii[0].fixtures).not.to.have.property(`timeout`);
+      expect(scenarii[0].fixtures).not.to.have.property(`name`);
+      expect(scenarii[0].fixtures).not.to.have.property(`scenario`);
     });
   });
 

--- a/test/parser/yaml.js
+++ b/test/parser/yaml.js
@@ -3,6 +3,7 @@
 const expect = require(`chai`).expect;
 const join = require(`path`).join;
 const parse = require(`../../src/parser/yaml`);
+const Test = require(`../../src/engine/test`);
 
 const fixtures = join(__dirname, `..`, `fixtures`, `yaml`);
 
@@ -49,19 +50,36 @@ describe(`YAML Spec parser`, () => {
     return parse(join(fixtures, `noname.yaml`)).
       then(scenarii => {
         expect(scenarii).to.have.lengthOf(2);
+        expect(scenarii[0]).to.be.an.instanceOf(Test);
         expect(scenarii[0]).to.have.property(`name`).that.equals(`test 1`);
+        expect(scenarii[1]).to.be.an.instanceOf(Test);
         expect(scenarii[1]).to.have.property(`name`).that.equals(`test 2`);
       });
+  });
+
+  it(`should extract test timeout`, () => {
+    return parse(join(fixtures, `timeout.yaml`)).then(scenarii => {
+      expect(scenarii).to.have.lengthOf(2);
+      expect(scenarii[0]).to.be.an.instanceOf(Test);
+      expect(scenarii[0]).to.have.property(`timeout`).that.equals(3000);
+      expect(scenarii[1]).to.be.an.instanceOf(Test);
+      expect(scenarii[1]).to.have.property(`timeout`).that.equals(2000);
+    });
   });
 
   it(`should extract fixtures`, () => {
     return parse(join(fixtures, `simple.yaml`)).
       then(scenarii => {
         expect(scenarii).to.have.lengthOf(1);
+        expect(scenarii[0]).to.be.an.instanceOf(Test);
         expect(scenarii[0]).to.have.property(`name`).that.equals(`first test`);
+        expect(scenarii[0]).to.have.property(`timeout`).that.equals(500);
         expect(scenarii[0].fixtures).to.have.property(`id`).that.equals(123456);
         expect(scenarii[0].fixtures).to.have.property(`insurer`).that.equals(`IN1`);
         expect(scenarii[0].fixtures).to.have.property(`scoring`).that.equals(`C1`);
+        expect(scenarii[0].fixtures).not.to.have.property(`timeout`);
+        expect(scenarii[0].fixtures).not.to.have.property(`name`);
+        expect(scenarii[0].fixtures).not.to.have.property(`scenario`);
       });
   });
 

--- a/test/runner/mocha.js
+++ b/test/runner/mocha.js
@@ -1,4 +1,5 @@
 'use strict';
+/* eslint no-invalid-this: 0 */
 
 const expect = require(`chai`).expect;
 const run = require(`../../src/runner/mocha`);
@@ -35,7 +36,6 @@ describe(`Mocha runner`, () => {
   });
 
   it(`should execute in specified current directory`, function() {
-    /* eslint no-invalid-this: 0 */
     this.timeout(3000);
 
     // given a test that check its own current directory
@@ -45,7 +45,7 @@ describe(`Mocha runner`, () => {
       }
     };`;
     return run([
-      new Test(`test 1`, content, {cwd: __dirname.replace(/\\/g, `\\\\`)}, __dirname)
+      new Test(`test 1`, content, {cwd: __dirname.replace(/\\/g, `\\\\`)}, 2000, __dirname)
     ], opts).
       then(report => {
         expect(report).to.be.exist;
@@ -55,7 +55,7 @@ describe(`Mocha runner`, () => {
       then(() => {
         return run([
           new Test(`test 2`, content, {cwd: process.cwd().replace(/\\/g, `\\\\`)})
-        ], null, opts);
+        ], opts);
       }).
       then(report => {
         expect(report).to.be.exist;
@@ -64,34 +64,30 @@ describe(`Mocha runner`, () => {
       });
   });
 
-  it(`should execute failing test after timeout expire`, () => {
+  it(`should report timed-out test with custom timeout`, () => {
     const test = new Test(`test 1`, `'use strict';
-      return () => {
-       return new Promise(() => {});
-      };
-    `, {config: {timeout: 500}});
+      return (done) => {};
+    `, {}, 500);
     return run([test], opts).then(report => {
       expect(report).to.be.exist;
       expect(report).to.have.property(`tests`).that.equals(1);
       expect(report).to.have.property(`failures`).that.equals(1);
-      expect(report).to.have.property(`duration`).that.below(510);
       expect(report).to.have.property(`duration`).at.least(500);
+      expect(report).to.have.property(`duration`).that.below(550);
     });
   });
 
-  it(`should execute failing test after default timeout expire`, function() {
+  it(`should report timed-out test with default 2s timeout`, function() {
     this.timeout(3000);
     const test = new Test(`test 1`, `'use strict';
-      return () => {
-        return new Promise(() => {});
-      };
+      return (done) => {};
     `, {});
     return run([test], opts).then(report => {
       expect(report).to.be.exist;
       expect(report).to.have.property(`tests`).that.equals(1);
       expect(report).to.have.property(`failures`).that.equals(1);
-      expect(report).to.have.property(`duration`).that.below(2010);
       expect(report).to.have.property(`duration`).at.least(2000);
+      expect(report).to.have.property(`duration`).that.below(2050);
     });
   });
 

--- a/test/utils/logger.js
+++ b/test/utils/logger.js
@@ -43,11 +43,34 @@ describe(`Logger`, () => {
     });
 
     it(`should read level from file for new loggers`, done => {
-      fs.writeFile(confPath, `[test:logger1]\nlevel=warn\n\n[logger2]\nlevel=error`, err => {
+      fs.writeFile(confPath, `[test:logger1]\nlevel=info\n\n[logger2]\nlevel=error`, err => {
         expect(err).not.to.exist;
         setTimeout(() => {
-          expect(getLogger(`test:logger1`).level).to.equals(`warn`);
+          expect(getLogger(`test:logger1`).level).to.equals(`info`);
           expect(getLogger(`logger2`).level).to.equals(`error`);
+          expect(getLogger(`logger3`).level).to.equals(`warn`);
+          done();
+        }, 10);
+      });
+    });
+
+    it(`should apply general level`, done => {
+      fs.writeFile(confPath, `[all]\nlevel=info`, err => {
+        expect(err).not.to.exist;
+        setTimeout(() => {
+          expect(getLogger(`test:logger1`).level).to.equals(`info`);
+          expect(getLogger(`logger2`).level).to.equals(`info`);
+          done();
+        }, 10);
+      });
+    });
+
+    it(`should override general level with specific level`, done => {
+      fs.writeFile(confPath, `[all]\nlevel=info\n\n[logger1]\nlevel=error`, err => {
+        expect(err).not.to.exist;
+        setTimeout(() => {
+          expect(getLogger(`logger1`).level).to.equals(`error`);
+          expect(getLogger(`logger2`).level).to.equals(`info`);
           done();
         }, 10);
       });
@@ -103,7 +126,6 @@ describe(`Logger`, () => {
         });
       });
     });
-
   });
 
   describe(`given a mocked console`, () => {


### PR DESCRIPTION
- add test coverage for Nunjuck unquote helper
- fix timeout that applies to all suite and provide dedicated input field
- configure all loggers at once with `all`
